### PR TITLE
Investissements vers l'API : correction notif erreur

### DIFF
--- a/includes/data/wdgwprest/wdgwprest-entities/wdgwprest-investment.php
+++ b/includes/data/wdgwprest/wdgwprest-entities/wdgwprest-investment.php
@@ -176,9 +176,7 @@ class WDGWPREST_Entity_Investment {
 		$parameters = WDGWPREST_Entity_Investment::set_post_parameters( $campaign, $edd_payment_item );
 		if ( !empty( $parameters ) ) {
 			$buffer = WDGWPRESTLib::call_post_wdg( 'investment', $parameters );
-			if ( isset( $buffer->code ) && $buffer->code == 200 ) {
-				$buffer = TRUE;
-			} else {
+			if ( $buffer === FALSE ) {
 				NotificationsEmails::investment_to_api_error_admin( $edd_payment_item );
 			}
 		}


### PR DESCRIPTION
Bon y'avait jamais de code qui était renvoyé. Juste le contenu si c'est ok. Sinon c'est false...