### PR TITLE
Notifications LW : Prélèvement : ne pas commencer à initialiser direc…

### DIFF
--- a/includes/control/gateways/lemonway-notification.php
+++ b/includes/control/gateways/lemonway-notification.php
@@ -545,7 +545,7 @@ class LemonwayNotification {
 
 							$declaration->status = WDGROIDeclaration::$status_initializing;
 							$declaration->update();
-							$declaration->init_rois_and_tax();
+							WDGQueue::add_init_declaration_rois( $declaration->id );
 							break;
 						}
 					}


### PR DESCRIPTION
…tement (pour éviter les exécutions parallèles)